### PR TITLE
Inform 6 changes & Adventuron version

### DIFF
--- a/Adventuron/GetLamp.txt
+++ b/Adventuron/GetLamp.txt
@@ -1,0 +1,66 @@
+start_at = anEmptyOffice
+
+strings {
+   dark_room : string "a dark room. You cannot see a thing."; // default
+}
+
+locations {
+   anEmptyOffice   : location "You are in an empty office. There is a door to the south, and a locked door to the east.";
+   theStockRoom    : location "You are in the stock room. There is a door to the north." ;
+   aWaitingRoom    : location "You are in {dark_room}" ;
+   theWorldOutside : location "You are in the world outside!" ;
+}
+
+connections {
+   from, direction, to = [
+      anEmptyOffice,    south, theStockRoom,
+      anEmptyOffice,    east, aWaitingRoom, 
+      aWaitingRoom,     south, theWorldOutside, 
+   ]
+}
+
+objects {
+   key  : object  "a key" at="theStockRoom";
+   lamp : object  "a lamp" at="anEmptyOffice";
+}
+
+booleans {
+   lamp_lit : boolean "false";
+}
+
+on_startup {
+    : print "GetLamp by Taciano Perez";
+}
+
+on_command {
+   : match "light lamp"  {
+      : if (is_carried "lamp") {
+         : print "Now you have a lit lamp." ;
+         : set_true "lamp_lit" ;
+         : set_string var="dark_room" text="You are in a waiting room. You see doors leading west and south." ;
+      }
+      : else {
+         : print "You don't have a lamp." ; 
+         }
+   }
+}
+
+on_describe {
+   : if (is_at "theWorldOutside" ) {
+      : print "Congratulations, you have won the game!" ;
+      : win_game ;
+   }
+}
+
+barriers {
+   black_door : door {
+      from  = anEmptyOffice
+      to    = aWaitingRoom
+      key   = key
+   }
+   lamp_block : block {
+      block_when_not = lamp_lit
+      location       = theWorldOutside
+      message        = "You cannot go in that direction."
+   }
+}

--- a/Adventuron/README.md
+++ b/Adventuron/README.md
@@ -1,0 +1,11 @@
+Adventuron Version
+
+https://adventuron.io/
+
+Note: Door has to be opened after unlocking
+
+Bug: Could potentially light lamp, drop it, and then go into dark room and still be able to see.
+
+Solution: take lamp, s, take key, n, unlock door, open door, e, s 
+
+8 bit conversion - https://adventuron.io/documentation/8bit.html

--- a/Inform 7/Inform 6/GetLamp.inf
+++ b/Inform 7/Inform 6/GetLamp.inf
@@ -1,0 +1,62 @@
+Constant Story "GetLamp";
+
+Include "Parser";
+Include "VerbLib";
+
+Object  anEmptyOffice "An Empty Office"
+ has    light
+ with   description "You are in an empty office. There is a door to the south.",
+ s_to   theStockRoom, 
+ e_to   black_door
+ ;
+
+Object  theStockRoom "The Stock Room"
+ has    light
+ with   description "You are in the stock room. There is a door to the north.",
+ n_to anEmptyOffice;
+
+Object  aWaitingRoom "A Waiting Room"
+ with   description "You are in a waiting room. You see doors leading west and south.",
+ w_to   anEmptyOffice,
+ s_to   theWorldOutside;
+
+Object  theWorldOutside "The World Outside"
+ has light
+ with   description "You are in the world outside!",
+ each_turn [; if (player in theWorldOutside) deadflag = 2; ],
+ n_to   aWaitingRoom;
+
+Object door_key "a key" theStockRoom
+ with name 'key',
+ has ;
+
+Object black_door "black door" anEmptyOffice
+ with name "door",
+ description "A black door.",
+  when_closed "A locked door bars your way to a room east.",
+  when_open "An open door leads east.",
+ after[;
+  unlock: give self open;
+ ],
+ door_to aWaitingRoom,
+ door_dir e_to,
+ with_key door_key,
+ has door lockable openable locked static;
+
+Object a_lamp "a lamp" anEmptyOffice
+ with name 'lamp',
+after [;
+           SwitchOn: give self light;
+           SwitchOff: give self ~light;
+       ],
+ has switchable;
+
+[ Initialise;
+    location = anEmptyOffice;
+];
+
+[ DeadMessage;
+if (deadflag == 2) print "Congratulations, you have won the game!";
+];
+
+Include "Grammar";

--- a/Inform 7/Inform 6/GetLamp.inf
+++ b/Inform 7/Inform 6/GetLamp.inf
@@ -26,7 +26,7 @@ Object  theWorldOutside "The World Outside"
  each_turn [; if (player in theWorldOutside) deadflag = 2; ],
  n_to   aWaitingRoom;
 
-Object door_key "a key" theStockRoom
+Object door_key "key" theStockRoom
  with name 'key',
  has ;
 
@@ -43,7 +43,7 @@ Object black_door "black door" anEmptyOffice
  with_key door_key,
  has door lockable openable locked static;
 
-Object a_lamp "a lamp" anEmptyOffice
+Object a_lamp "lamp" anEmptyOffice
  with name 'lamp',
 after [;
            SwitchOn: give self light;

--- a/Inform 7/Inform 6/README.md
+++ b/Inform 7/Inform 6/README.md
@@ -1,0 +1,7 @@
+Inform 6 Version
+
+This version of Inform was created to be compatible with Infocom interpreters / games.
+
+This should be suitable for playing on 8 and 16 bit computers (and emulators) via https://github.com/johanberntsson/PunyInform
+
+Note: "Light" has not been implemented, so use "switch on lamp"


### PR DESCRIPTION
I've taken out the 'a ' in the Inform 6 objects so they should list correctly in the inventory now.

I've also added an Adventuron version as another example which should also work on later stage 8 bit machines. (Let me know if you don't want it and I can remove it from the branch)
